### PR TITLE
Kill beer

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,7 +25,6 @@ gulp.task("browserSync:reload", done => {
 
 // Basic watch tasks
 gulp.task("watch:all", () => {
-  plugins.beer.server.start();
   browserSync(config.settings.browserSync);
 
   gulp.watch(

--- a/src/config/tasks/compile-scss.js
+++ b/src/config/tasks/compile-scss.js
@@ -3,7 +3,10 @@ const cssnano = require("cssnano");
 const through2 = require("through2");
 
 const postcssPlugins = [
-  postcssPresetEnv({ browsers: ["last 5 versions", "ie >= 9"] }),
+  postcssPresetEnv({ 
+    browsers: ["last 5 versions", "ie >= 9"],
+    autoprefixer: { grid: true } 
+  }),
   cssnano({
     preset: [
       "default",


### PR DESCRIPTION
Removed the beer line that was crashing it.
Added gird support to autoprefixer, primarily for ie11 support.